### PR TITLE
fix: vector realloc error when size = 0

### DIFF
--- a/src/vector.hpp
+++ b/src/vector.hpp
@@ -556,7 +556,7 @@ class vector {
 
     template <class... Args>
     void m_realloc_insert(iterator pos, Args &&...args) {
-        const size_type len = size() * 2;
+        const size_type len = size() + tstl::max<size_type>(1, size());
         pointer old_start = m_start;
         pointer old_finish = m_finish;
         const size_type elems_before = pos - begin();

--- a/test/test-stack.cpp
+++ b/test/test-stack.cpp
@@ -6,8 +6,10 @@
 #include <iostream>
 
 int test_stack() {
-    tstl::stack<int> s1;
+    tstl::stack<int, tstl::vector<int>> s1;
     s1.push(1);
+    s1.push(2);
+    s1.pop();
     std::cout << s1.top() << std::endl;
     return 0;
 }


### PR DESCRIPTION
当 vector 的大小为 0 时，倍增扩展大小仍为 0。

对 size = 0 的情况特殊判断即可修复。